### PR TITLE
Got delete post functionality working!

### DIFF
--- a/graphql/resolvers/comment.js
+++ b/graphql/resolvers/comment.js
@@ -5,7 +5,7 @@ const { AuthenticationError, ApolloError } = require('apollo-server-express');
 module.exports = {
   Mutation: {
       // Ensures that only users who are logged in can create a comment
-    async createComment(_, {  body, postId }, { user = null }) {
+    async createComment(_, { body, postId }, { user = null }) {
       if (!user) {
         throw new AuthenticationError('You must login to create a comment');
       }

--- a/graphql/resolvers/index.js
+++ b/graphql/resolvers/index.js
@@ -13,4 +13,3 @@ const postResolvers = require('./post');
 const commentResolvers = require('./comment');
 
 module.exports = [userResolvers, postResolvers, commentResolvers];
-

--- a/graphql/resolvers/post.js
+++ b/graphql/resolvers/post.js
@@ -1,5 +1,5 @@
 const { Post } = require('../../models');
-const checkAuth = require("../context/index");
+const { verifyToken } = require("../context/index");
 
 const { AuthenticationError } = require('apollo-server-express');
 
@@ -7,6 +7,7 @@ module.exports = {
 
     // Resolver function to handle mutations and queries related to Post model
   Mutation: {
+    // Create Post Mutation
     async createPost(_, { title, body, }, { user = null }) {
       if (!user) {
         throw new AuthenticationError('You must login to create a post');
@@ -17,7 +18,29 @@ module.exports = {
         body,
       });
     },
-  },
+
+
+  // Delete Post Mutation
+   async deletePost(_, { postId }, { user = null }){
+
+    // Ensures you must be logged in to delete a post
+    if (!user) {
+      throw new AuthenticationError('You must login to delete your post');
+    }
+      // Finds a specific post with a matching id in the database
+        const post = Post.findByPk(postId);
+
+        // Checks if the user's id matches the id of the user who created the post to be deleted
+        if(user.userId === post.userId){
+          Post.destroy({
+            where: { id: postId }
+           })
+          return 'Post deleted successfully';
+        } else {
+            throw new AuthenticationError('Action not allowed');
+        }
+      }
+    },
 
   // Get all posts in the database
   Query: {

--- a/graphql/schemas/post.js
+++ b/graphql/schemas/post.js
@@ -32,6 +32,7 @@ extend type Query {
 
  extend type Mutation {
      createPost(title: String!, body: String!): CreatePostResponse
+     deletePost(postId: Int!): String!
  }
 
  type CreatePostResponse {
@@ -42,3 +43,4 @@ extend type Query {
  }
 `;
 // note: removed category as an input field and therefore removed it as a response 1611892769668 1611892807209
+//      deletePost(postId: Int!): String!


### PR DESCRIPTION
Delete post mutation is now functional! 

![image](https://user-images.githubusercontent.com/14916152/106335619-0a978d80-6242-11eb-9b25-a8094f3cfe55.png)

1. - It works by taking in the id of a post as an input, and checks if a user is currently logged in
2. - Then, it finds the post in the database with a matching id as the postId that was passed in as an input and stores it in a variable.
3. - Afterwards, it checks if the id of the user who is currently logged in matches the id of the user who created that post;
4.  if they match, then it calls on sequelize's `Model.destroy()` function and specifies which post to delete by passing in the postId.

Running delete post in GraphQL playground:
![image](https://user-images.githubusercontent.com/14916152/106335966-b7720a80-6242-11eb-903c-65f0158be65c.png)

Using getPost to get the post at the deleted id
![image](https://user-images.githubusercontent.com/14916152/106335991-c5279000-6242-11eb-904b-4e2759882ba3.png)

